### PR TITLE
Prepare for deploy5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,4 +51,5 @@ end
 
 gem 'haml-rails'
 gem 'erb2haml'
+gem 'dotenv-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.4)
     debug_inspector (0.0.2)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     erb2haml (0.1.5)
       html2haml
     erubis (2.7.0)
@@ -176,6 +180,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   coffee-rails (~> 4.1.0)
+  dotenv-rails
   erb2haml
   haml-rails
   jbuilder (~> 2.0)


### PR DESCRIPTION
# What
dotenv-railsのインストール

# Why
awskey等重要な情報を本番に上げないため
